### PR TITLE
Add `hideDefaultOnly` option

### DIFF
--- a/web/Composition.php
+++ b/web/Composition.php
@@ -59,6 +59,11 @@ class Composition extends Component implements \ArrayAccess
     public $hidden = true;
 
     /**
+     * @var boolean Disable composition prefixes in URLs only for default language. Takes effect only when `hidden` option is disabled.
+     */
+    public $hideDefaultOnly = false;
+
+    /**
      * @var string Url matching prefix, which is used for all the modules (e.g. an e-store requireds a language
      * as the cms needs this informations too). After proccessing this informations, they will be removed
      * from the url for further proccessing.
@@ -240,8 +245,11 @@ class Composition extends Component implements \ArrayAccess
      */
     public function createRouteEnsure(array $overrideKeys = [])
     {
-        return $this->hidden ? '' : $this->createRoute($overrideKeys);
+        return $this->hidden || (!$this->hidden && $this->langShortCode == $this->defaultLangShortCode && $this->hideDefaultOnly) ? '' : $this->createRoute($overrideKeys);
     }
+
+//{if ($this->langShortCode != 'ru') {echo $this->langShortCode;exit;}echo $this->langShortCode;
+//}
     
     /**
      * Create compositon route based on the provided keys (to override), if no keys provided


### PR DESCRIPTION
When enabled, composition prefixes will be hidden only for default language. Takes effect only when `hidden` option is disabled.